### PR TITLE
Explicitly add QUADPACK assets within bertha-nuclear

### DIFF
--- a/bertha-nuclear.f
+++ b/bertha-nuclear.f
@@ -9946,3 +9946,770 @@ C
       END
 C
 C
+C**********************************************************************C
+C ==================================================================== C
+C  [16] QUADPACK: COPIED FROM THE OFFICIAL SOURCE.                     C
+C       COMMENTS REMOVED -- REFER TO ORIGINAL FOR DOCUMENTATION.       C
+C ==================================================================== C
+C  ROUTINES AND FUNCTIONS:                                             C
+C -------------------------------------------------------------------- C
+C   [A] DQAGS:  ESTIMATES THE INTEGRAL OF A FUNCTION (CONTROLLER).     C
+C   [B] DQAGSE: ESTIMATES THE INTEGRAL OF A FUNCTION (DRIVER).         C
+C   [C] D1MACH: RETURNS DOUBLE-PRECISION MACHINE-DEPENDENT CONSTANTS.  C
+C   [D] DQELG:  CARRIES OUT THE EPSILON EXTRAPOLATION ALGORITHM.       C
+C   [E] DQK21:  CARRIES OUT A 21-POINT GAUSS-KRONRON QUADRATURE RULE.  C
+C   [F] DQPSRT: MAINTAINS THE ORDER OF A LIST OF LOCAL ERROR ESTIMATES.C
+C   [G] I1MACH: OBTAINS INTEGER MACHINE-DEPENDENT CONSTANTS.           C
+C   [H] XERROR: ERROR-THROWING ROUTINE FOR PRINTING TO TERMINAL.       C
+C**********************************************************************C
+C
+C
+      SUBROUTINE DQAGS(F,A,B,EPSABS,EPSREL,RESULT,ABSERR,NEVAL,IER,
+     *                                     LIMIT,LENW,LAST,IWORK,WORK)
+C**********************************************************************C
+C                                                                      C
+C            DDDDDDD   QQQQQQ      AA     GGGGGG   SSSSSS              C
+C            DD    DD QQ    QQ    AAAA   GG    GG SS    SS             C
+C            DD    DD QQ    QQ   AA  AA  GG    GG SS                   C
+C            DD    DD QQ    QQ  AA    AA GG        SSSSSS              C
+C            DD    DD QQ   QQQ  AAAAAAAA GG   GGG       SS             C
+C            DD    DD QQ    QQ  AA    AA GG    GG SS    SS             C
+C            DDDDDDD   QQQQQQ Q AA    AA  GGGGGG   SSSSSS              C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  DQAGS ESTIMATES THE INTEGRAL OF A FUNCTION (CONTROLLER).            C
+C**********************************************************************C
+      DOUBLE PRECISION A,ABSERR,B,EPSABS,EPSREL,F,RESULT,WORK
+      INTEGER IER,IWORK,LAST,LENW,LIMIT,LVL,L1,L2,L3,NEVAL
+      DIMENSION IWORK(LIMIT),WORK(LENW)
+C
+      EXTERNAL F
+C
+C***FIRST EXECUTABLE STATEMENT  DQAGS
+      IER = 6
+      NEVAL = 0
+      LAST = 0
+      RESULT = 0.0D+00
+      ABSERR = 0.0D+00
+      IF(LIMIT.LT.1.OR.LENW.LT.LIMIT*4) GO TO 10
+C
+C         PREPARE CALL FOR DQAGSE.
+C
+      L1 = LIMIT+1
+      L2 = LIMIT+L1
+      L3 = LIMIT+L2
+C
+      CALL DQAGSE(F,A,B,EPSABS,EPSREL,LIMIT,RESULT,ABSERR,NEVAL,
+     *  IER,WORK(1),WORK(L1),WORK(L2),WORK(L3),IWORK,LAST)
+C
+C         CALL ERROR HANDLER IF NECESSARY.
+C
+      LVL = 0
+10    IF(IER.EQ.6) LVL = 1
+      IF(IER.NE.0) CALL XERROR('ABNORMAL RETURN FROM DQAGS',26,IER,LVL)
+      RETURN
+      END
+C
+C
+      SUBROUTINE DQAGSE(F,A,B,EPSABS,EPSREL,LIMIT,RESULT,ABSERR,NEVAL,
+     *   IER,ALIST,BLIST,RLIST,ELIST,IORD,LAST)
+C**********************************************************************C
+C                                                                      C
+C        DDDDDDD   QQQQQQ      AA     GGGGGG   SSSSSS  EEEEEEEE        C
+C        DD    DD QQ    QQ    AAAA   GG    GG SS    SS EE              C
+C        DD    DD QQ    QQ   AA  AA  GG    GG SS       EE              C
+C        DD    DD QQ    QQ  AA    AA GG        SSSSSS  EEEEEE          C
+C        DD    DD QQ   QQQ  AAAAAAAA GG   GGG       SS EE              C
+C        DD    DD QQ    QQ  AA    AA GG    GG SS    SS EE              C
+C        DDDDDDD   QQQQQQ Q AA    AA  GGGGGG   SSSSSS  EEEEEEEE        C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  DQAGSE ESTIMATES THE INTEGRAL OF A FUNCTION (DRIVER).               C
+C**********************************************************************C
+      DOUBLE PRECISION A,ABSEPS,ABSERR,ALIST,AREA,AREA1,AREA12,AREA2,A1,
+     *  A2,B,BLIST,B1,B2,CORREC,DABS,DEFABS,DEFAB1,DEFAB2,D1MACH,DMAX1,
+     *  DRES,ELIST,EPMACH,EPSABS,EPSREL,ERLARG,ERLAST,ERRBND,ERRMAX,
+     *  ERROR1,ERROR2,ERRO12,ERRSUM,ERTEST,F,OFLOW,RESABS,RESEPS,RESULT,
+     *  RES3LA,RLIST,RLIST2,SMALL,UFLOW
+      INTEGER ID,IER,IERRO,IORD,IROFF1,IROFF2,IROFF3,JUPBND,K,KSGN,
+     *  KTMIN,LAST,LIMIT,MAXERR,NEVAL,NRES,NRMAX,NUMRL2
+      LOGICAL EXTRAP,NOEXT
+C
+      DIMENSION ALIST(LIMIT),BLIST(LIMIT),ELIST(LIMIT),IORD(LIMIT),
+     * RES3LA(3),RLIST(LIMIT),RLIST2(52)
+C
+      EXTERNAL F
+C
+C***FIRST EXECUTABLE STATEMENT  DQAGSE
+      EPMACH = D1MACH(4)
+C
+C            TEST ON VALIDITY OF PARAMETERS
+C            ------------------------------
+      IER = 0
+      NEVAL = 0
+      LAST = 0
+      RESULT = 0.0D+00
+      ABSERR = 0.0D+00
+      ALIST(1) = A
+      BLIST(1) = B
+      RLIST(1) = 0.0D+00
+      ELIST(1) = 0.0D+00
+      IF(EPSABS.LE.0.0D+00.AND.EPSREL.LT.DMAX1(0.5D+02*EPMACH,0.5D-28))
+     *   IER = 6
+      IF(IER.EQ.6) GO TO 999
+C
+C           FIRST APPROXIMATION TO THE INTEGRAL
+C           -----------------------------------
+C
+      UFLOW = D1MACH(1)
+      OFLOW = D1MACH(2)
+      IERRO = 0
+      CALL DQK21(F,A,B,RESULT,ABSERR,DEFABS,RESABS)
+C
+C           TEST ON ACCURACY.
+C
+      DRES = DABS(RESULT)
+      ERRBND = DMAX1(EPSABS,EPSREL*DRES)
+      LAST = 1
+      RLIST(1) = RESULT
+      ELIST(1) = ABSERR
+      IORD(1) = 1
+      IF(ABSERR.LE.1.0D+02*EPMACH*DEFABS.AND.ABSERR.GT.ERRBND) IER = 2
+      IF(LIMIT.EQ.1) IER = 1
+      IF(IER.NE.0.OR.(ABSERR.LE.ERRBND.AND.ABSERR.NE.RESABS).OR.
+     *  ABSERR.EQ.0.0D+00) GO TO 140
+C
+C           INITIALIZATION
+C           --------------
+C
+      RLIST2(1) = RESULT
+      ERRMAX = ABSERR
+      MAXERR = 1
+      AREA = RESULT
+      ERRSUM = ABSERR
+      ABSERR = OFLOW
+      NRMAX = 1
+      NRES = 0
+      NUMRL2 = 2
+      KTMIN = 0
+      EXTRAP = .FALSE.
+      NOEXT = .FALSE.
+      IROFF1 = 0
+      IROFF2 = 0
+      IROFF3 = 0
+      KSGN = -1
+      IF(DRES.GE.(0.1D+01-0.5D+02*EPMACH)*DEFABS) KSGN = 1
+C
+C           MAIN DO-LOOP
+C           ------------
+C
+      DO 90 LAST = 2,LIMIT
+C
+C           BISECT THE SUBINTERVAL WITH THE NRMAX-TH LARGEST ERROR
+C           ESTIMATE.
+C
+        A1 = ALIST(MAXERR)
+        B1 = 0.5D+00*(ALIST(MAXERR)+BLIST(MAXERR))
+        A2 = B1
+        B2 = BLIST(MAXERR)
+        ERLAST = ERRMAX
+        CALL DQK21(F,A1,B1,AREA1,ERROR1,RESABS,DEFAB1)
+        CALL DQK21(F,A2,B2,AREA2,ERROR2,RESABS,DEFAB2)
+C
+C           IMPROVE PREVIOUS APPROXIMATIONS TO INTEGRAL
+C           AND ERROR AND TEST FOR ACCURACY.
+C
+        AREA12 = AREA1+AREA2
+        ERRO12 = ERROR1+ERROR2
+        ERRSUM = ERRSUM+ERRO12-ERRMAX
+        AREA = AREA+AREA12-RLIST(MAXERR)
+        IF(DEFAB1.EQ.ERROR1.OR.DEFAB2.EQ.ERROR2) GO TO 15
+        IF(DABS(RLIST(MAXERR)-AREA12).GT.0.1D-04*DABS(AREA12)
+     *  .OR.ERRO12.LT.0.99D+00*ERRMAX) GO TO 10
+        IF(EXTRAP) IROFF2 = IROFF2+1
+        IF(.NOT.EXTRAP) IROFF1 = IROFF1+1
+   10   IF(LAST.GT.10.AND.ERRO12.GT.ERRMAX) IROFF3 = IROFF3+1
+   15   RLIST(MAXERR) = AREA1
+        RLIST(LAST) = AREA2
+        ERRBND = DMAX1(EPSABS,EPSREL*DABS(AREA))
+C
+C           TEST FOR ROUNDOFF ERROR AND EVENTUALLY SET ERROR FLAG.
+C
+        IF(IROFF1+IROFF2.GE.10.OR.IROFF3.GE.20) IER = 2
+        IF(IROFF2.GE.5) IERRO = 3
+C
+C           SET ERROR FLAG IN THE CASE THAT THE NUMBER OF SUBINTERVALS
+C           EQUALS LIMIT.
+C
+        IF(LAST.EQ.LIMIT) IER = 1
+C
+C           SET ERROR FLAG IN THE CASE OF BAD INTEGRAND BEHAVIOUR
+C           AT A POINT OF THE INTEGRATION RANGE.
+C
+        IF(DMAX1(DABS(A1),DABS(B2)).LE.(0.1D+01+0.1D+03*EPMACH)*
+     *  (DABS(A2)+0.1D+04*UFLOW)) IER = 4
+C
+C           APPEND THE NEWLY-CREATED INTERVALS TO THE LIST.
+C
+        IF(ERROR2.GT.ERROR1) GO TO 20
+        ALIST(LAST) = A2
+        BLIST(MAXERR) = B1
+        BLIST(LAST) = B2
+        ELIST(MAXERR) = ERROR1
+        ELIST(LAST) = ERROR2
+        GO TO 30
+   20   ALIST(MAXERR) = A2
+        ALIST(LAST) = A1
+        BLIST(LAST) = B1
+        RLIST(MAXERR) = AREA2
+        RLIST(LAST) = AREA1
+        ELIST(MAXERR) = ERROR2
+        ELIST(LAST) = ERROR1
+C
+C           CALL SUBROUTINE DQPSRT TO MAINTAIN THE DESCENDING ORDERING
+C           IN THE LIST OF ERROR ESTIMATES AND SELECT THE SUBINTERVAL
+C           WITH NRMAX-TH LARGEST ERROR ESTIMATE (TO BE BISECTED NEXT).
+C
+   30   CALL DQPSRT(LIMIT,LAST,MAXERR,ERRMAX,ELIST,IORD,NRMAX)
+C ***JUMP OUT OF DO-LOOP
+        IF(ERRSUM.LE.ERRBND) GO TO 115
+C ***JUMP OUT OF DO-LOOP
+        IF(IER.NE.0) GO TO 100
+        IF(LAST.EQ.2) GO TO 80
+        IF(NOEXT) GO TO 90
+        ERLARG = ERLARG-ERLAST
+        IF(DABS(B1-A1).GT.SMALL) ERLARG = ERLARG+ERRO12
+        IF(EXTRAP) GO TO 40
+C
+C           TEST WHETHER THE INTERVAL TO BE BISECTED NEXT IS THE
+C           SMALLEST INTERVAL.
+C
+        IF(DABS(BLIST(MAXERR)-ALIST(MAXERR)).GT.SMALL) GO TO 90
+        EXTRAP = .TRUE.
+        NRMAX = 2
+   40   IF(IERRO.EQ.3.OR.ERLARG.LE.ERTEST) GO TO 60
+C
+C           THE SMALLEST INTERVAL HAS THE LARGEST ERROR.
+C           BEFORE BISECTING DECREASE THE SUM OF THE ERRORS OVER THE
+C           LARGER INTERVALS (ERLARG) AND PERFORM EXTRAPOLATION.
+C
+        ID = NRMAX
+        JUPBND = LAST
+        IF(LAST.GT.(2+LIMIT/2)) JUPBND = LIMIT+3-LAST
+        DO 50 K = ID,JUPBND
+          MAXERR = IORD(NRMAX)
+          ERRMAX = ELIST(MAXERR)
+C ***JUMP OUT OF DO-LOOP
+          IF(DABS(BLIST(MAXERR)-ALIST(MAXERR)).GT.SMALL) GO TO 90
+          NRMAX = NRMAX+1
+   50   CONTINUE
+C
+C           PERFORM EXTRAPOLATION.
+C
+   60   NUMRL2 = NUMRL2+1
+        RLIST2(NUMRL2) = AREA
+        CALL DQELG(NUMRL2,RLIST2,RESEPS,ABSEPS,RES3LA,NRES)
+        KTMIN = KTMIN+1
+        IF(KTMIN.GT.5.AND.ABSERR.LT.0.1D-02*ERRSUM) IER = 5
+        IF(ABSEPS.GE.ABSERR) GO TO 70
+        KTMIN = 0
+        ABSERR = ABSEPS
+        RESULT = RESEPS
+        CORREC = ERLARG
+        ERTEST = DMAX1(EPSABS,EPSREL*DABS(RESEPS))
+C ***JUMP OUT OF DO-LOOP
+        IF(ABSERR.LE.ERTEST) GO TO 100
+C
+C           PREPARE BISECTION OF THE SMALLEST INTERVAL.
+C
+   70   IF(NUMRL2.EQ.1) NOEXT = .TRUE.
+        IF(IER.EQ.5) GO TO 100
+        MAXERR = IORD(1)
+        ERRMAX = ELIST(MAXERR)
+        NRMAX = 1
+        EXTRAP = .FALSE.
+        SMALL = SMALL*0.5D+00
+        ERLARG = ERRSUM
+        GO TO 90
+   80   SMALL = DABS(B-A)*0.375D+00
+        ERLARG = ERRSUM
+        ERTEST = ERRBND
+        RLIST2(2) = AREA
+   90 CONTINUE
+C
+C           SET FINAL RESULT AND ERROR ESTIMATE.
+C           ------------------------------------
+C
+  100 IF(ABSERR.EQ.OFLOW) GO TO 115
+      IF(IER+IERRO.EQ.0) GO TO 110
+      IF(IERRO.EQ.3) ABSERR = ABSERR+CORREC
+      IF(IER.EQ.0) IER = 3
+      IF(RESULT.NE.0.0D+00.AND.AREA.NE.0.0D+00) GO TO 105
+      IF(ABSERR.GT.ERRSUM) GO TO 115
+      IF(AREA.EQ.0.0D+00) GO TO 130
+      GO TO 110
+  105 IF(ABSERR/DABS(RESULT).GT.ERRSUM/DABS(AREA)) GO TO 115
+C
+C           TEST ON DIVERGENCE.
+C
+  110 IF(KSGN.EQ.(-1).AND.DMAX1(DABS(RESULT),DABS(AREA)).LE.
+     * DEFABS*0.1D-01) GO TO 130
+      IF(0.1D-01.GT.(RESULT/AREA).OR.(RESULT/AREA).GT.0.1D+03
+     * .OR.ERRSUM.GT.DABS(AREA)) IER = 6
+      GO TO 130
+C
+C           COMPUTE GLOBAL INTEGRAL SUM.
+C
+  115 RESULT = 0.0D+00
+      DO 120 K = 1,LAST
+         RESULT = RESULT+RLIST(K)
+  120 CONTINUE
+      ABSERR = ERRSUM
+  130 IF(IER.GT.2) IER = IER-1
+  140 NEVAL = 42*LAST-21
+  999 RETURN
+      END
+C
+C
+      FUNCTION D1MACH ( I )
+      IMPLICIT NONE
+C**********************************************************************C
+C                                                                      C
+C         DDDDDDD   11  MM       MM    AA     CCCCCC  HH    HH         C
+C         DD    DD 111  MMM     MMM   AAAA   CC    CC HH    HH         C
+C         DD    DD  11  MMMM   MMMM  AA  AA  CC       HH    HH         C
+C         DD    DD  11  MM MM MM MM AA    AA CC       HHHHHHHH         C
+C         DD    DD  11  MM  MMM  MM AAAAAAAA CC       HH    HH         C
+C         DD    DD  11  MM   M   MM AA    AA CC    CC HH    HH         C
+C         DDDDDDD  1111 MM       MM AA    AA  CCCCCC  HH    HH         C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  D1MACH RETURNS DOUBLE-PRECISION MACHINE-DEPENDENT CONSTANTS.        C
+C**********************************************************************C
+      DOUBLE PRECISION D1MACH
+      INTEGER DIVER(4)
+      DOUBLE PRECISION DMACH(5)
+      INTEGER I
+      INTEGER LARGE(4)
+      INTEGER LOG10(4)
+      INTEGER RIGHT(4)
+      INTEGER SMALL(4)
+
+      EQUIVALENCE ( DMACH(1), SMALL(1) )
+      EQUIVALENCE ( DMACH(2), LARGE(1) )
+      EQUIVALENCE ( DMACH(3), RIGHT(1) )
+      EQUIVALENCE ( DMACH(4), DIVER(1) )
+      EQUIVALENCE ( DMACH(5), LOG10(1) )
+       DATA SMALL(1),SMALL(2) /          0,    1048576 /
+       DATA LARGE(1),LARGE(2) /         -1, 2146435071 /
+       DATA RIGHT(1),RIGHT(2) /          0, 1017118720 /
+       DATA DIVER(1),DIVER(2) /          0, 1018167296 /
+       DATA LOG10(1),LOG10(2) / 1352628735, 1070810131 /
+C
+      IF ( I .LT. 1  .OR.  5 .LT. I ) THEN
+        WRITE ( *, '(A)' ) ' '
+        WRITE ( *, '(A)' ) 'D1MACH - FATAL ERROR!'
+        WRITE ( *, '(A)' ) '  I OUT OF BOUNDS.'
+        STOP
+      END IF
+
+      D1MACH = DMACH(I)
+
+      RETURN
+      END
+C
+C
+      SUBROUTINE DQELG(N,EPSTAB,RESULT,ABSERR,RES3LA,NRES)
+C**********************************************************************C
+C                                                                      C
+C             DDDDDDD   QQQQQQ   EEEEEEEE LL       GGGGGG              C
+C             DD    DD QQ    QQ  EE       LL      GG    GG             C
+C             DD    DD QQ    QQ  EE       LL      GG                   C
+C             DD    DD QQ    QQ  EEEEEE   LL      GG                   C
+C             DD    DD QQ   QQQ  EE       LL      GG   GGG             C
+C             DD    DD QQ    QQ  EE       LL      GG    GG             C
+C             DDDDDDD   QQQQQQ Q EEEEEEEE LLLLLLLL GGGGGG              C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  DQELG CARRIES OUT THE EPSILON EXTRAPOLATION ALGORITHM.              C
+C**********************************************************************C
+      DOUBLE PRECISION ABSERR,DABS,DELTA1,DELTA2,DELTA3,DMAX1,D1MACH,
+     *  EPMACH,EPSINF,EPSTAB,ERROR,ERR1,ERR2,ERR3,E0,E1,E1ABS,E2,E3,
+     *  OFLOW,RES,RESULT,RES3LA,SS,TOL1,TOL2,TOL3
+      INTEGER I,IB,IB2,IE,INDX,K1,K2,K3,LIMEXP,N,NEWELM,NRES,NUM
+      DIMENSION EPSTAB(52),RES3LA(3)
+C
+C***FIRST EXECUTABLE STATEMENT  DQELG
+      EPMACH = D1MACH(4)
+      OFLOW = D1MACH(2)
+      NRES = NRES+1
+      ABSERR = OFLOW
+      RESULT = EPSTAB(N)
+      IF(N.LT.3) GO TO 100
+      LIMEXP = 50
+      EPSTAB(N+2) = EPSTAB(N)
+      NEWELM = (N-1)/2
+      EPSTAB(N) = OFLOW
+      NUM = N
+      K1 = N
+      DO 40 I = 1,NEWELM
+        K2 = K1-1
+        K3 = K1-2
+        RES = EPSTAB(K1+2)
+        E0 = EPSTAB(K3)
+        E1 = EPSTAB(K2)
+        E2 = RES
+        E1ABS = DABS(E1)
+        DELTA2 = E2-E1
+        ERR2 = DABS(DELTA2)
+        TOL2 = DMAX1(DABS(E2),E1ABS)*EPMACH
+        DELTA3 = E1-E0
+        ERR3 = DABS(DELTA3)
+        TOL3 = DMAX1(E1ABS,DABS(E0))*EPMACH
+        IF(ERR2.GT.TOL2.OR.ERR3.GT.TOL3) GO TO 10
+C
+C           IF E0, E1 AND E2 ARE EQUAL TO WITHIN MACHINE
+C           ACCURACY, CONVERGENCE IS ASSUMED.
+C           RESULT = E2
+C           ABSERR = ABS(E1-E0)+ABS(E2-E1)
+C
+        RESULT = RES
+        ABSERR = ERR2+ERR3
+C ***JUMP OUT OF DO-LOOP
+        GO TO 100
+   10   E3 = EPSTAB(K1)
+        EPSTAB(K1) = E1
+        DELTA1 = E1-E3
+        ERR1 = DABS(DELTA1)
+        TOL1 = DMAX1(E1ABS,DABS(E3))*EPMACH
+C
+C           IF TWO ELEMENTS ARE VERY CLOSE TO EACH OTHER, OMIT
+C           A PART OF THE TABLE BY ADJUSTING THE VALUE OF N
+C
+        IF(ERR1.LE.TOL1.OR.ERR2.LE.TOL2.OR.ERR3.LE.TOL3) GO TO 20
+        SS = 0.1D+01/DELTA1+0.1D+01/DELTA2-0.1D+01/DELTA3
+        EPSINF = DABS(SS*E1)
+C
+C           TEST TO DETECT IRREGULAR BEHAVIOUR IN THE TABLE, AND
+C           EVENTUALLY OMIT A PART OF THE TABLE ADJUSTING THE VALUE
+C           OF N.
+C
+        IF(EPSINF.GT.0.1D-03) GO TO 30
+   20   N = I+I-1
+C ***JUMP OUT OF DO-LOOP
+        GO TO 50
+C
+C           COMPUTE A NEW ELEMENT AND EVENTUALLY ADJUST
+C           THE VALUE OF RESULT.
+C
+   30   RES = E1+0.1D+01/SS
+        EPSTAB(K1) = RES
+        K1 = K1-2
+        ERROR = ERR2+DABS(RES-E2)+ERR3
+        IF(ERROR.GT.ABSERR) GO TO 40
+        ABSERR = ERROR
+        RESULT = RES
+   40 CONTINUE
+C
+C           SHIFT THE TABLE.
+C
+   50 IF(N.EQ.LIMEXP) N = 2*(LIMEXP/2)-1
+      IB = 1
+      IF((NUM/2)*2.EQ.NUM) IB = 2
+      IE = NEWELM+1
+      DO 60 I=1,IE
+        IB2 = IB+2
+        EPSTAB(IB) = EPSTAB(IB2)
+        IB = IB2
+   60 CONTINUE
+      IF(NUM.EQ.N) GO TO 80
+      INDX = NUM-N+1
+      DO 70 I = 1,N
+        EPSTAB(I)= EPSTAB(INDX)
+        INDX = INDX+1
+   70 CONTINUE
+   80 IF(NRES.GE.4) GO TO 90
+      RES3LA(NRES) = RESULT
+      ABSERR = OFLOW
+      GO TO 100
+C
+C           COMPUTE ERROR ESTIMATE
+C
+   90 ABSERR = DABS(RESULT-RES3LA(3))+DABS(RESULT-RES3LA(2))
+     *  +DABS(RESULT-RES3LA(1))
+      RES3LA(1) = RES3LA(2)
+      RES3LA(2) = RES3LA(3)
+      RES3LA(3) = RESULT
+  100 ABSERR = DMAX1(ABSERR,0.5D+01*EPMACH*DABS(RESULT))
+      RETURN
+      END
+C
+C
+      SUBROUTINE DQK21(F,A,B,RESULT,ABSERR,RESABS,RESASC)
+C**********************************************************************C
+C                                                                      C
+C              DDDDDDD   QQQQQQ   KK    KK  222222   11                C
+C              DD    DD QQ    QQ  KK   KK  22    22 111                C
+C              DD    DD QQ    QQ  KK  KK         22  11                C
+C              DD    DD QQ    QQ  KKKKK         22   11                C
+C              DD    DD QQ   QQQ  KK  KK      22     11                C
+C              DD    DD QQ    QQ  KK   KK   22       11                C
+C              DDDDDDD   QQQQQQ Q KK    KK 22222222 1111               C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  DQK21 CARRIES OUT A 21-POINT GAUSS-KRONRON QUADRATURE RULE.         C
+C**********************************************************************C
+      DOUBLE PRECISION A,ABSC,ABSERR,B,CENTR,DABS,DHLGTH,DMAX1,DMIN1,
+     *  D1MACH,EPMACH,F,FC,FSUM,FVAL1,FVAL2,FV1,FV2,HLGTH,RESABS,RESASC,
+     *  RESG,RESK,RESKH,RESULT,UFLOW,WG,WGK,XGK
+      INTEGER J,JTW,JTWM1
+      EXTERNAL F
+C
+      DIMENSION FV1(10),FV2(10),WG(5),WGK(11),XGK(11)
+C
+      DATA WG  (  1) / 0.0666713443 0868813759 3568809893 332 D0 /
+      DATA WG  (  2) / 0.1494513491 5058059314 5776339657 697 D0 /
+      DATA WG  (  3) / 0.2190863625 1598204399 5534934228 163 D0 /
+      DATA WG  (  4) / 0.2692667193 0999635509 1226921569 469 D0 /
+      DATA WG  (  5) / 0.2955242247 1475287017 3892994651 338 D0 /
+C
+      DATA XGK (  1) / 0.9956571630 2580808073 5527280689 003 D0 /
+      DATA XGK (  2) / 0.9739065285 1717172007 7964012084 452 D0 /
+      DATA XGK (  3) / 0.9301574913 5570822600 1207180059 508 D0 /
+      DATA XGK (  4) / 0.8650633666 8898451073 2096688423 493 D0 /
+      DATA XGK (  5) / 0.7808177265 8641689706 3717578345 042 D0 /
+      DATA XGK (  6) / 0.6794095682 9902440623 4327365114 874 D0 /
+      DATA XGK (  7) / 0.5627571346 6860468333 9000099272 694 D0 /
+      DATA XGK (  8) / 0.4333953941 2924719079 9265943165 784 D0 /
+      DATA XGK (  9) / 0.2943928627 0146019813 1126603103 866 D0 /
+      DATA XGK ( 10) / 0.1488743389 8163121088 4826001129 720 D0 /
+      DATA XGK ( 11) / 0.0000000000 0000000000 0000000000 000 D0 /
+C
+      DATA WGK (  1) / 0.0116946388 6737187427 8064396062 192 D0 /
+      DATA WGK (  2) / 0.0325581623 0796472747 8818972459 390 D0 /
+      DATA WGK (  3) / 0.0547558965 7435199603 1381300244 580 D0 /
+      DATA WGK (  4) / 0.0750396748 1091995276 7043140916 190 D0 /
+      DATA WGK (  5) / 0.0931254545 8369760553 5065465083 366 D0 /
+      DATA WGK (  6) / 0.1093871588 0229764189 9210590325 805 D0 /
+      DATA WGK (  7) / 0.1234919762 6206585107 7958109831 074 D0 /
+      DATA WGK (  8) / 0.1347092173 1147332592 8054001771 707 D0 /
+      DATA WGK (  9) / 0.1427759385 7706008079 7094273138 717 D0 /
+      DATA WGK ( 10) / 0.1477391049 0133849137 4841515972 068 D0 /
+      DATA WGK ( 11) / 0.1494455540 0291690566 4936468389 821 D0 /
+C
+C***FIRST EXECUTABLE STATEMENT  DQK21
+      EPMACH = D1MACH(4)
+      UFLOW = D1MACH(1)
+C
+      CENTR = 0.5D+00*(A+B)
+      HLGTH = 0.5D+00*(B-A)
+      DHLGTH = DABS(HLGTH)
+C
+C           COMPUTE THE 21-POINT KRONROD APPROXIMATION TO
+C           THE INTEGRAL, AND ESTIMATE THE ABSOLUTE ERROR.
+C
+      RESG = 0.0D+00
+      FC = F(CENTR)
+      RESK = WGK(11)*FC
+      RESABS = DABS(RESK)
+      DO 10 J=1,5
+        JTW = 2*J
+        ABSC = HLGTH*XGK(JTW)
+        FVAL1 = F(CENTR-ABSC)
+        FVAL2 = F(CENTR+ABSC)
+        FV1(JTW) = FVAL1
+        FV2(JTW) = FVAL2
+        FSUM = FVAL1+FVAL2
+        RESG = RESG+WG(J)*FSUM
+        RESK = RESK+WGK(JTW)*FSUM
+        RESABS = RESABS+WGK(JTW)*(DABS(FVAL1)+DABS(FVAL2))
+   10 CONTINUE
+      DO 15 J = 1,5
+        JTWM1 = 2*J-1
+        ABSC = HLGTH*XGK(JTWM1)
+        FVAL1 = F(CENTR-ABSC)
+        FVAL2 = F(CENTR+ABSC)
+        FV1(JTWM1) = FVAL1
+        FV2(JTWM1) = FVAL2
+        FSUM = FVAL1+FVAL2
+        RESK = RESK+WGK(JTWM1)*FSUM
+        RESABS = RESABS+WGK(JTWM1)*(DABS(FVAL1)+DABS(FVAL2))
+   15 CONTINUE
+      RESKH = RESK*0.5D+00
+      RESASC = WGK(11)*DABS(FC-RESKH)
+      DO 20 J=1,10
+        RESASC = RESASC+WGK(J)*(DABS(FV1(J)-RESKH)+DABS(FV2(J)-RESKH))
+   20 CONTINUE
+      RESULT = RESK*HLGTH
+      RESABS = RESABS*DHLGTH
+      RESASC = RESASC*DHLGTH
+      ABSERR = DABS((RESK-RESG)*HLGTH)
+      IF(RESASC.NE.0.0D+00.AND.ABSERR.NE.0.0D+00)
+     *  ABSERR = RESASC*DMIN1(0.1D+01,(0.2D+03*ABSERR/RESASC)**1.5D+00)
+      IF(RESABS.GT.UFLOW/(0.5D+02*EPMACH)) ABSERR = DMAX1
+     *  ((EPMACH*0.5D+02)*RESABS,ABSERR)
+      RETURN
+      END
+C
+C
+      SUBROUTINE DQPSRT(LIMIT,LAST,MAXERR,ERMAX,ELIST,IORD,NRMAX)
+C**********************************************************************C
+C                                                                      C
+C        DDDDDDD   QQQQQQ   PPPPPPP   SSSSSS  RRRRRRR  TTTTTTTT        C
+C        DD    DD QQ    QQ  PP    PP SS    SS RR    RR    TT           C
+C        DD    DD QQ    QQ  PP    PP SS       RR    RR    TT           C
+C        DD    DD QQ    QQ  PP    PP  SSSSSS  RR    RR    TT           C
+C        DD    DD QQ   QQQ  PPPPPPP        SS RRRRRRR     TT           C
+C        DD    DD QQ    QQ  PP       SS    SS RR    RR    TT           C
+C        DDDDDDD   QQQQQQ Q PP        SSSSSS  RR    RR    TT           C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  DQPSRT MAINTAINS THE ORDER OF A LIST OF LOCAL ERROR ESTIMATES.      C
+C**********************************************************************C
+      DOUBLE PRECISION ELIST,ERMAX,ERRMAX,ERRMIN
+      INTEGER I,IBEG,IDO,IORD,ISUCC,J,JBND,JUPBN,K,LAST,LIMIT,MAXERR,
+     *  NRMAX
+      DIMENSION ELIST(LAST),IORD(LAST)
+C
+C***FIRST EXECUTABLE STATEMENT  DQPSRT
+      IF(LAST.GT.2) GO TO 10
+      IORD(1) = 1
+      IORD(2) = 2
+      GO TO 90
+C
+C           THIS PART OF THE ROUTINE IS ONLY EXECUTED IF, DUE TO A
+C           DIFFICULT INTEGRAND, SUBDIVISION INCREASED THE ERROR
+C           ESTIMATE. IN THE NORMAL CASE THE INSERT PROCEDURE SHOULD
+C           START AFTER THE NRMAX-TH LARGEST ERROR ESTIMATE.
+C
+   10 ERRMAX = ELIST(MAXERR)
+      IF(NRMAX.EQ.1) GO TO 30
+      IDO = NRMAX-1
+      DO 20 I = 1,IDO
+        ISUCC = IORD(NRMAX-1)
+C ***JUMP OUT OF DO-LOOP
+        IF(ERRMAX.LE.ELIST(ISUCC)) GO TO 30
+        IORD(NRMAX) = ISUCC
+        NRMAX = NRMAX-1
+   20    CONTINUE
+C
+C           COMPUTE THE NUMBER OF ELEMENTS IN THE LIST TO BE MAINTAINED
+C           IN DESCENDING ORDER. THIS NUMBER DEPENDS ON THE NUMBER OF
+C           SUBDIVISIONS STILL ALLOWED.
+C
+   30 JUPBN = LAST
+      IF(LAST.GT.(LIMIT/2+2)) JUPBN = LIMIT+3-LAST
+      ERRMIN = ELIST(LAST)
+C
+C           INSERT ERRMAX BY TRAVERSING THE LIST TOP-DOWN,
+C           STARTING COMPARISON FROM THE ELEMENT ELIST(IORD(NRMAX+1)).
+C
+      JBND = JUPBN-1
+      IBEG = NRMAX+1
+      IF(IBEG.GT.JBND) GO TO 50
+      DO 40 I=IBEG,JBND
+        ISUCC = IORD(I)
+C ***JUMP OUT OF DO-LOOP
+        IF(ERRMAX.GE.ELIST(ISUCC)) GO TO 60
+        IORD(I-1) = ISUCC
+   40 CONTINUE
+   50 IORD(JBND) = MAXERR
+      IORD(JUPBN) = LAST
+      GO TO 90
+C
+C           INSERT ERRMIN BY TRAVERSING THE LIST BOTTOM-UP.
+C
+   60 IORD(I-1) = MAXERR
+      K = JBND
+      DO 70 J=I,JBND
+        ISUCC = IORD(K)
+C ***JUMP OUT OF DO-LOOP
+        IF(ERRMIN.LT.ELIST(ISUCC)) GO TO 80
+        IORD(K+1) = ISUCC
+        K = K-1
+   70 CONTINUE
+      IORD(I) = LAST
+      GO TO 90
+   80 IORD(K+1) = LAST
+C
+C           SET MAXERR AND ERMAX.
+C
+   90 MAXERR = IORD(NRMAX)
+      ERMAX = ELIST(MAXERR)
+      RETURN
+      END
+C
+C
+      INTEGER FUNCTION I1MACH ( I )
+C**********************************************************************C
+C                                                                      C
+C           IIII  11  MM       MM    AA     CCCCCC  HH    HH           C
+C            II  111  MMM     MMM   AAAA   CC    CC HH    HH           C
+C            II   11  MMMM   MMMM  AA  AA  CC       HH    HH           C
+C            II   11  MM MM MM MM AA    AA CC       HHHHHHHH           C
+C            II   11  MM  MMM  MM AAAAAAAA CC       HH    HH           C
+C            II   11  MM   M   MM AA    AA CC    CC HH    HH           C
+C           IIII 1111 MM       MM AA    AA  CCCCCC  HH    HH           C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  I1MACH OBTAINS INTEGER MACHINE-DEPENDENT CONSTANTS.                 C
+C**********************************************************************C
+      INTEGER IMACH(16),OUTPUT
+      EQUIVALENCE (IMACH(4),OUTPUT)
+
+      DATA IMACH( 1) /    5 /
+      DATA IMACH( 2) /    6 /
+      DATA IMACH( 3) /    7 /
+      DATA IMACH( 4) /    6 /
+      DATA IMACH( 5) /   32 /
+      DATA IMACH( 6) /    4 /
+      DATA IMACH( 7) /    2 /
+      DATA IMACH( 8) /   31 /
+      DATA IMACH( 9) / 2147483647 /
+      DATA IMACH(10) /    2 /
+      DATA IMACH(11) /   24 /
+      DATA IMACH(12) / -125 /
+      DATA IMACH(13) /  128 /
+      DATA IMACH(14) /   53 /
+      DATA IMACH(15) / -1021 /
+      DATA IMACH(16) /  1024 /
+C
+C***FIRST EXECUTABLE STATEMENT  I1MACH
+C
+      IF ( I .LT. 1  .OR.  I .GT. 16 ) THEN
+        WRITE ( *, '(A)' ) ' '
+        WRITE ( *, '(A)' ) 'I1MACH - FATAL ERROR!'
+        WRITE ( *, '(A)' ) '  I OUT OF BOUNDS.'
+        STOP
+      END IF
+
+      I1MACH = IMACH(I)
+
+      RETURN
+      END
+C
+C
+      SUBROUTINE XERROR (XMESS, NMESS, NERR, LEVEL)
+C**********************************************************************C
+C                                                                      C
+C        XX     XX EEEEEEEE RRRRRRR  RRRRRRR   OOOOOO  RRRRRRR         C
+C         XX   XX  EE       RR    RR RR    RR OO    OO RR    RR        C
+C          XX XX   EE       RR    RR RR    RR OO    OO RR    RR        C
+C           XXX    EEEEEE   RR    RR RR    RR OO    OO RR    RR        C
+C          XX XX   EE       RRRRRRR  RRRRRRR  OO    OO RRRRRRR         C
+C         XX   XX  EE       RR    RR RR    RR OO    OO RR    RR        C
+C        XX     XX EEEEEEEE RR    RR RR    RR  OOOOOO  RR    RR        C
+C                                                                      C
+C -------------------------------------------------------------------- C
+C  XERROR IS AN ERROR-THROWING ROUTINE FOR PRINTING TO THE TERMINAL.   C
+C**********************************************************************C
+      CHARACTER*26 XMESS
+
+      IF (LEVEL.GE.1) THEN
+      IERR=I1MACH(3)
+      WRITE(IERR,'(1X,A)') XMESS(1:NMESS)
+      WRITE(IERR,'('' ERROR NUMBER = '',I5,'', MESSAGE LEVEL = '',I5)')
+     .      NERR,LEVEL
+      END IF
+      RETURN
+      END


### PR DESCRIPTION
This avoids the tedious linking of QUADPACK with the dedicated nuclear Bertha program during the compile process.

Note that I suspect the Wichmann-Kroll calculators are broken, but not because of this work -- I get the same results when I couple them like before (on a Macbook).